### PR TITLE
feat(routine): 루틴 등록 + 성장 모드 + 기록 기반 제안 통합

### DIFF
--- a/features/routine/api/routines.ts
+++ b/features/routine/api/routines.ts
@@ -1,0 +1,363 @@
+// features/routine/api/routines.ts
+/**
+ * ✅ 현재는 "목데이터"로 동작합니다.
+ * ✅ 아래 각 함수 안에 명세서에 맞춘 "실서버 연동 코드"를 주석으로 함께 제공하니,
+ *    나중에 주석 해제 + api 클라이언트 연결만 하면 바로 실제 API로 전환할 수 있습니다.
+ *
+ * API 명세서 요약 (필요 엔드포인트)
+ * - GET    /api/routines                          : 내 루틴 목록
+ * - POST   /api/routines                          : 루틴 생성
+ * - GET    /api/routines/:id                      : 루틴 상세 (옵션)
+ * - PUT    /api/routines/:id                      : 루틴 수정(제목은 수정 불가)
+ * - DELETE /api/routines/:id                      : 루틴 삭제
+ * - GET    /api/routines/categories               : 카테고리 목록 (비인증)
+ * - GET    /api/routines/adaptation-check         : 성장/감소 후보 (옵션)
+ * - PATCH  /api/routines/:id/target?action=...    : 목표 조정(INCREASE/DECREASE/RESET) (옵션)
+ */
+
+import type { AddRoutineForm, Routine } from "../types";
+
+/* ─────────────────────────────────────────────────────────────────────────────
+  섹션 1) 목데이터 (현재 활성)
+────────────────────────────────────────────────────────────────────────────── */
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// 카테고리 표시명(프론트) 예시: "운동" | "학업" | "기타"
+// 명세서의 서버 카테고리 코드는 "HEALTH" | "LEARNING" | ...
+// 지금은 목이므로 프론트 표시명을 그대로 사용합니다.
+let DB: Routine[] = [
+  {
+    id: 1,
+    title: "영단어 20개 암기",
+    category: "학업",
+    subtitleHint: "7일 연속 성공! 강도를 높여볼까요?",
+    streakDays: 30,
+    growthMode: true,
+    goalType: "count",
+    goalValue: 20,
+    growthPeriodDays: 1,
+    growthIncrement: 1,
+    history: [
+      { date: "2025-09-01", completed: true },
+      { date: "2025-09-02", completed: true },
+      { date: "2025-09-03", completed: true },
+    ],
+  },
+  {
+    id: 2,
+    title: "근력운동 1시간",
+    category: "운동",
+    subtitleHint: "3일 연속 실패! 강도를 줄여볼까요?",
+    streakDays: 0,
+    growthMode: true,
+    goalType: "time",
+    goalValue: 60, // 분 단위
+    growthPeriodDays: 3,
+    growthIncrement: 5, // 분 단위 증가
+    history: [
+      { date: "2025-09-02", completed: false },
+      { date: "2025-09-03", completed: false },
+      { date: "2025-09-04", completed: false }, // 오늘까지 3일 연속 실패
+    ],
+  },
+
+  {
+    id: 3,
+    title: "독서 30분 하기",
+    category: "기타",
+    subtitleHint: "",
+    streakDays: 10,
+    growthMode: false, // 성장 모드 아님
+    history: [],
+  },
+];
+
+/** 루틴 목록 조회 (목) */
+export async function fetchRoutines(): Promise<Routine[]> {
+  await sleep(120);
+  // 깊은 복사로 안전하게 반환
+  return JSON.parse(JSON.stringify(DB));
+}
+
+/** 루틴 생성 (목) */
+export async function addRoutineApi(form: AddRoutineForm): Promise<Routine> {
+  await sleep(100);
+  const r: Routine = {
+    id: Date.now(), // 임시 ID
+    title: form.title,
+    category: form.category,
+    growthMode: form.growthMode,
+    goalType: form.growthMode ? form.goalType : undefined,
+    goalValue: form.growthMode ? form.goalValue : undefined,
+    growthPeriodDays: form.growthMode ? form.growthPeriodDays : undefined,
+    growthIncrement: form.growthMode ? form.growthIncrement : undefined,
+    subtitleHint: "",
+    streakDays: 0,
+    history: [],
+  };
+  DB = [r, ...DB];
+  return JSON.parse(JSON.stringify(r));
+}
+
+/** 루틴 수정 (목) — 제목은 수정하지 않는다고 가정(명세서와 맞춤) */
+export async function updateRoutineApi(id: number, form: AddRoutineForm): Promise<Routine> {
+  await sleep(120);
+  DB = DB.map((r) =>
+    r.id === id
+      ? ({
+          ...r,
+          // 명세서상 title 수정은 불가 → title은 유지하고 나머지만 반영
+          category: form.category ?? r.category,
+          growthMode: !!form.growthMode,
+          goalType: form.growthMode ? form.goalType : undefined,
+          goalValue: form.growthMode ? form.goalValue : undefined,
+          growthPeriodDays: form.growthMode ? form.growthPeriodDays : undefined,
+          growthIncrement: form.growthMode ? form.growthIncrement : undefined,
+        } as Routine)
+      : r,
+  );
+  const found = DB.find((r) => r.id === id)!;
+  return JSON.parse(JSON.stringify(found));
+}
+
+/** 루틴 삭제 (목) */
+export async function deleteRoutineApi(id: number): Promise<void> {
+  await sleep(80);
+  DB = DB.filter((r) => r.id !== id);
+}
+
+/** 완료 토글 (목) — 서버 명세에 별도 완료 API가 없으므로 목에서는 no-op */
+export async function completeRoutineApi(_id: number): Promise<void> {
+  await sleep(60);
+}
+
+/** (옵션) 카테고리 목록 (목) */
+export async function fetchRoutineCategories(): Promise<{ code: string; description: string }[]> {
+  await sleep(60);
+  return [
+    { code: "HEALTH", description: "건강" },
+    { code: "LEARNING", description: "학습" },
+    { code: "MINDFULNESS", description: "마음 챙김" },
+    { code: "DIET", description: "식습관" },
+    { code: "HOBBY", description: "취미" },
+  ];
+}
+
+/** (옵션) 적응형 후보 (목) */
+export async function fetchAdaptationCheck(): Promise<any> {
+  await sleep(60);
+  return {
+    growthCandidates: {
+      candidates: [
+        {
+          routineId: 1,
+          routineTitle: "푸쉬업 챌린지",
+          category: "HEALTH",
+          currentTarget: 10,
+          suggestedTarget: 12,
+          completedCycleDays: 7,
+          totalCycleDays: 7,
+        },
+      ],
+      totalCount: 1,
+      type: "GROWTH",
+    },
+    reductionCandidates: {
+      candidates: [
+        {
+          routineId: 2,
+          routineTitle: "독서하기",
+          category: "LEARNING",
+          currentTarget: 60,
+          suggestedTarget: 50,
+          failedDays: 5,
+          totalCycleDays: 7,
+        },
+      ],
+      totalCount: 1,
+      type: "REDUCTION",
+    },
+  };
+}
+
+/** (옵션) 목표 조정 (목) */
+export async function patchRoutineTarget(
+  _routineId: number,
+  _action: "INCREASE" | "DECREASE" | "RESET",
+): Promise<any> {
+  await sleep(60);
+  return {
+    routineId: _routineId,
+    routineTitle: "푸쉬업 챌린지",
+    previousValue: 10,
+    newValue: _action === "INCREASE" ? 12 : 10,
+    action: _action,
+  };
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+  섹션 2) 실서버 연동 코드 (주석) — 명세서에 맞춰 즉시 사용 가능
+  ⚠️ 실제 사용 시: 아래 주석을 해제하고, 상단 목 코드를 제거/분기하세요.
+  - axios 클라이언트 예시: utils/api/client.ts 의 api 인스턴스(Authorization 자동 주입)
+  - 카테고리 코드 ↔ 프론트 표시명 매핑 유틸 포함
+────────────────────────────────────────────────────────────────────────────── */
+/*
+import { api } from "@/utils/api/client";
+
+// 공통 래퍼 타입
+type CommonResponse<T> = { code: string; message: string; data: T };
+
+// 서버 응답 모델
+type RoutineResp = {
+  routineId: number;
+  category: string;           // ex) "HEALTH"
+  title: string;
+  description?: string | null;
+  isGrowthMode: boolean;
+  targetType?: "NUMBER" | "TIME" | "DATE";
+  targetValue?: number | null;
+  growthCycleDays?: number | null;
+  targetIncrement?: number | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type RoutineListResp = {
+  routines: RoutineResp[];
+  totalCount: number;
+};
+
+// 카테고리 매핑 (표시명 ↔ 코드)
+const categoryLabelToCode = (label?: string): string | undefined => {
+  const map: Record<string, string> = {
+    "운동": "HEALTH",
+    "학업": "LEARNING",
+    "마음 챙김": "MINDFULNESS",
+    "식습관": "DIET",
+    "취미": "HOBBY",
+    "사회적 관계": "SOCIAL",
+    "업무": "WORK",
+    "재정 관리": "FINANCE",
+    "환경 정리": "ENVIRONMENT",
+    "습관 개선": "HABIT_IMPROVEMENT",
+  };
+  if (!label) return undefined;
+  return map[label] ?? label; // 이미 코드면 그대로
+};
+
+const categoryCodeToLabel = (code?: string): string | undefined => {
+  const map: Record<string, string> = {
+    HEALTH: "운동",
+    LEARNING: "학업",
+    MINDFULNESS: "마음 챙김",
+    DIET: "식습관",
+    HOBBY: "취미",
+    SOCIAL: "사회적 관계",
+    WORK: "업무",
+    FINANCE: "재정 관리",
+    ENVIRONMENT: "환경 정리",
+    HABIT_IMPROVEMENT: "습관 개선",
+  };
+  if (!code) return undefined;
+  return map[code] ?? code;
+};
+
+// 요청 바디 변환 (AddRoutineForm → 서버)
+const toCreateBody = (f: AddRoutineForm) => {
+  const targetType = f.growthMode ? (f.goalType === "time" ? "TIME" : "NUMBER") : undefined;
+  return {
+    category: categoryLabelToCode(f.category),
+    title: f.title,
+    description: "", // 필요 시 폼 확장
+    isGrowthMode: !!f.growthMode,
+    targetType,
+    targetValue: f.growthMode ? f.goalValue : undefined,
+    growthCycleDays: f.growthMode ? f.growthPeriodDays : undefined,
+    targetIncrement: f.growthMode ? f.growthIncrement : undefined,
+  };
+};
+
+// 서버 → 프론트 모델 변환 (RoutineResp → Routine)
+const toRoutine = (r: RoutineResp): Routine => ({
+  id: r.routineId,
+  title: r.title,
+  category: categoryCodeToLabel(r.category) ?? r.category,
+  subtitleHint: "",
+  streakDays: 0,
+  growthMode: !!r.isGrowthMode,
+  goalType: r.isGrowthMode ? (r.targetType === "TIME" ? "time" : "count") : undefined,
+  goalValue: r.isGrowthMode ? (r.targetValue ?? undefined) : undefined,
+  growthPeriodDays: r.isGrowthMode ? (r.growthCycleDays ?? undefined) : undefined,
+  growthIncrement: r.isGrowthMode ? (r.targetIncrement ?? undefined) : undefined,
+  history: [],
+});
+
+// [실서버] 목록
+export async function fetchRoutines(): Promise<Routine[]> {
+  const res = await api.get<CommonResponse<RoutineListResp>>("/api/routines");
+  return (res.data.data?.routines ?? []).map(toRoutine);
+}
+
+// [실서버] 생성
+export async function addRoutineApi(form: AddRoutineForm): Promise<Routine> {
+  const body = toCreateBody(form);
+  const res = await api.post<CommonResponse<RoutineResp>>("/api/routines", body);
+  return toRoutine(res.data.data);
+}
+
+// [실서버] 수정 (title 수정 불가 규칙 반영)
+export async function updateRoutineApi(id: number, form: AddRoutineForm): Promise<Routine> {
+  const body = toCreateBody(form);
+  delete (body as any).title; // 명세서: 제목 수정 불가
+  const res = await api.put<CommonResponse<RoutineResp>>(`/api/routines/${id}`, body);
+  return toRoutine(res.data.data);
+}
+
+// [실서버] 삭제
+export async function deleteRoutineApi(id: number): Promise<void> {
+  await api.delete<CommonResponse<null>>(`/api/routines/${id}`);
+}
+
+// [실서버] 완료 토글 — 명세서에 별도 엔드포인트가 없으므로 서버 스펙 확정 후 구현
+export async function completeRoutineApi(_id: number): Promise<void> {
+  // 예) await api.post(`/api/routines/${_id}/complete`);
+  return;
+}
+
+// [실서버] 카테고리
+export async function fetchRoutineCategories(): Promise<{ code: string; description: string }[]> {
+  const res = await api.get<CommonResponse<{ code: string; description: string }[]>>(
+    "/api/routines/categories",
+  );
+  return res.data.data || [];
+}
+
+// [실서버] 적응형 후보
+export async function fetchAdaptationCheck(): Promise<any> {
+  const res = await api.get<CommonResponse<any>>("/api/routines/adaptation-check");
+  return res.data.data;
+}
+
+// [실서버] 목표 조정
+export async function patchRoutineTarget(
+  routineId: number,
+  action: "INCREASE" | "DECREASE" | "RESET",
+) {
+  const res = await api.patch<CommonResponse<any>>(
+    `/api/routines/${routineId}/target`,
+    {},
+    { params: { action } },
+  );
+  return res.data.data;
+}
+*/
+
+/* ─────────────────────────────────────────────────────────────────────────────
+  섹션 3) 전환 가이드
+  - 지금은 목(섹션1)만 사용 중.
+  - 실서버로 바꿀 때는:
+    1) 위 섹션2의 주석을 해제하고
+    2) 섹션1의 목 코드를 제거(혹은 환경변수로 분기)
+    3) utils/api/client.ts 에서 Authorization 헤더가 자동으로 붙도록 설정
+────────────────────────────────────────────────────────────────────────────── */

--- a/features/routine/common/PopupHost.tsx
+++ b/features/routine/common/PopupHost.tsx
@@ -1,0 +1,12 @@
+// features/common/PopupHost.tsx
+import React from "react";
+import { usePopupQueue } from "./popupQueue";
+
+export default function PopupHost() {
+  // 개별 selector로 분리하면 디버깅도 쉬움
+  const current = usePopupQueue((s) => s.current);
+  const dismiss = usePopupQueue((s) => s.dismiss);
+
+  if (!current) return null;
+  return current.render(dismiss);
+}

--- a/features/routine/common/popupQueue.ts
+++ b/features/routine/common/popupQueue.ts
@@ -1,0 +1,39 @@
+// features/common/popupQueue.ts
+import { create } from "zustand";
+import { nanoid } from "nanoid/non-secure";
+import type { ReactElement } from "react";
+
+export type PopupItem = {
+  id: string;
+  render: (dismiss: () => void) => ReactElement | null;
+};
+
+type PopupQueueState = {
+  queue: PopupItem[];
+  current: PopupItem | null;
+  enqueue: (render: PopupItem["render"]) => string;
+  dismiss: () => void;
+  clear: () => void;
+};
+
+export const usePopupQueue = create<PopupQueueState>((set, get) => ({
+  queue: [],
+  current: null,
+  enqueue: (render) => {
+    const id = nanoid();
+    const item: PopupItem = { id, render };
+    const { current, queue } = get();
+    if (!current) set({ current: item });
+    else set({ queue: [...queue, item] });
+    return id;
+  },
+  dismiss: () => {
+    const { queue } = get();
+    if (queue.length === 0) set({ current: null });
+    else {
+      const [next, ...rest] = queue;
+      set({ current: next, queue: rest });
+    }
+  },
+  clear: () => set({ queue: [], current: null }),
+}));

--- a/features/routine/components/AddRoutineModal.tsx
+++ b/features/routine/components/AddRoutineModal.tsx
@@ -1,0 +1,337 @@
+// features/routine/components/AddRoutineModal.tsx
+import React, { useMemo, useState } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  Switch,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type { AddRoutineForm, GoalType, Routine } from "../types";
+
+const C = {
+  overlay: "rgba(0,0,0,0.55)",
+  card: "#FFFFFF",
+  label: "#5F5548",
+  border: "#E5E7EB",
+  text: "#111827",
+  placeholder: "#9CA3AF",
+  primary: "#6B5B4A",
+  primaryText: "#FFFFFF",
+  cancel: "#E5E7EB",
+  error: "#C2410C",
+};
+
+// ▼ 드롭다운 옵션
+const CATEGORY_OPTIONS = ["운동", "학업", "기타"] as const;
+
+type Errors = Partial<
+  Record<"title" | "category" | "goalValue" | "growthPeriodDays" | "growthIncrement", string>
+>;
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit: (f: AddRoutineForm) => void | Promise<void>;
+  mode?: "create" | "edit"; // ✨ 추가
+  initial?: Partial<Routine>; // ✨ 수정 초기값
+};
+
+export default function AddRoutineModal({
+  visible,
+  onClose,
+  onSubmit,
+  mode = "create",
+  initial,
+}: Props) {
+  // 초기값 주입(수정 모드 대응)
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [category, setCategory] = useState(initial?.category ?? "");
+  const [catOpen, setCatOpen] = useState(false);
+
+  const [growthMode, setGrowthMode] = useState(!!initial?.growthMode);
+  const [goalType, setGoalType] = useState<GoalType>(initial?.goalType ?? "count");
+
+  const onlyDigits = (t: string) => t.replace(/[^\d]/g, "");
+  const [goalValue, setGoalValue] = useState(
+    initial?.goalValue != null ? String(initial.goalValue) : "",
+  );
+  const [period, setPeriod] = useState(
+    initial?.growthPeriodDays != null ? String(initial.growthPeriodDays) : "",
+  );
+  const [increment, setIncrement] = useState(
+    initial?.growthIncrement != null ? String(initial.growthIncrement) : "",
+  );
+
+  const [errors, setErrors] = useState<Errors>({});
+
+  const validate = () => {
+    const e: Errors = {};
+    if (!title.trim()) e.title = "루틴 이름을 입력해 주세요";
+    if (!category.trim()) e.category = "카테고리를 선택해 주세요";
+    if (growthMode) {
+      if (!goalValue) e.goalValue = "목표를 입력해 주세요";
+      if (!period) e.growthPeriodDays = "난이도 증가 주기를 입력해 주세요";
+      if (!increment) e.growthIncrement = "난이도 증가 수치를 입력해 주세요";
+    }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const submit = async () => {
+    if (!validate()) return;
+    await onSubmit({
+      title: title.trim(),
+      category: category.trim(),
+      growthMode,
+      goalType: growthMode ? goalType : undefined,
+      goalValue: growthMode ? Number(goalValue) : undefined,
+      growthPeriodDays: growthMode ? Number(period) : undefined,
+      growthIncrement: growthMode ? Number(increment) : undefined,
+    });
+    onClose();
+  };
+
+  const Field = ({
+    value,
+    onChangeText,
+    placeholder,
+    errorKey,
+    keyboardType = "default" as "default" | "number-pad",
+  }: {
+    value: string;
+    onChangeText: (t: string) => void;
+    placeholder: string;
+    errorKey?: keyof Errors;
+    keyboardType?: "default" | "number-pad";
+  }) => {
+    const isErr = errorKey ? !!errors[errorKey] : false;
+    return (
+      <View>
+        <TextInput
+          placeholder={placeholder}
+          placeholderTextColor={C.placeholder}
+          value={value}
+          onChangeText={(t) => {
+            onChangeText(t);
+            if (errorKey && errors[errorKey]) setErrors({ ...errors, [errorKey]: undefined });
+          }}
+          keyboardType={keyboardType}
+          style={{
+            borderWidth: 1,
+            borderColor: isErr ? C.error : C.border,
+            borderRadius: 12,
+            paddingHorizontal: 12,
+            paddingVertical: 12,
+            fontSize: 15,
+            color: C.text,
+          }}
+        />
+        {isErr && (
+          <Text style={{ color: C.error, marginTop: 6, fontSize: 12 }}>{errors[errorKey!]}</Text>
+        )}
+      </View>
+    );
+  };
+
+  const incPlaceholder = goalType === "time" ? "난이도 증가 수치(분)" : "난이도 증가 수치";
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        behavior={Platform.select({ ios: "padding", android: undefined })}
+        style={{
+          flex: 1,
+          backgroundColor: C.overlay,
+          justifyContent: "center",
+          paddingHorizontal: 16,
+        }}
+      >
+        <View style={{ backgroundColor: C.card, borderRadius: 18, padding: 16 }}>
+          <Text style={{ color: C.label, fontWeight: "800", fontSize: 18, marginBottom: 12 }}>
+            {mode === "edit" ? "루틴 수정" : "루틴 추가"}
+          </Text>
+
+          <View style={{ gap: 12 }}>
+            <Field
+              value={title}
+              onChangeText={setTitle}
+              placeholder="루틴 이름을 입력해 주세요"
+              errorKey="title"
+            />
+
+            {/* ▼ 카테고리 드롭다운 */}
+            <View>
+              <Pressable
+                onPress={() => setCatOpen((v) => !v)}
+                style={{
+                  borderWidth: 1,
+                  borderColor: errors.category ? C.error : C.border,
+                  borderRadius: 12,
+                  paddingHorizontal: 12,
+                  paddingVertical: 12,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Text style={{ color: category ? C.text : C.placeholder, fontSize: 15 }}>
+                  {category || "카테고리를 선택해 주세요"}
+                </Text>
+                <Ionicons
+                  name={catOpen ? "chevron-up" : "chevron-down"}
+                  size={18}
+                  color={C.placeholder}
+                />
+              </Pressable>
+              {errors.category && (
+                <Text style={{ color: C.error, marginTop: 6, fontSize: 12 }}>
+                  {errors.category}
+                </Text>
+              )}
+              {catOpen && (
+                <View
+                  style={{
+                    marginTop: 6,
+                    borderWidth: 1,
+                    borderColor: C.border,
+                    borderRadius: 12,
+                    overflow: "hidden",
+                    backgroundColor: "#fff",
+                  }}
+                >
+                  {CATEGORY_OPTIONS.map((c, i) => (
+                    <Pressable
+                      key={c}
+                      onPress={() => {
+                        setCategory(c);
+                        setCatOpen(false);
+                        if (errors.category) setErrors({ ...errors, category: undefined });
+                      }}
+                      style={{
+                        paddingVertical: 12,
+                        paddingHorizontal: 12,
+                        borderTopWidth: i === 0 ? 0 : 1,
+                        borderTopColor: C.border,
+                      }}
+                    >
+                      <Text style={{ fontSize: 15, color: C.text }}>{c}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+              )}
+            </View>
+
+            {/* 성장 모드 */}
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "space-between",
+              }}
+            >
+              <Text style={{ color: C.label, fontSize: 15 }}>성장 모드</Text>
+              <Switch value={growthMode} onValueChange={setGrowthMode} />
+            </View>
+
+            {growthMode && (
+              <View style={{ gap: 10 }}>
+                {/* 목표 타입 토글 */}
+                <View style={{ flexDirection: "row", gap: 8 }}>
+                  <Pressable
+                    onPress={() => setGoalType("count")}
+                    style={{
+                      flex: 1,
+                      height: 40,
+                      borderRadius: 10,
+                      borderWidth: 1,
+                      borderColor: C.border,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      backgroundColor: goalType === "count" ? "#F5F5F5" : "#fff",
+                    }}
+                  >
+                    <Text>목표 횟수</Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => setGoalType("time")}
+                    style={{
+                      flex: 1,
+                      height: 40,
+                      borderRadius: 10,
+                      borderWidth: 1,
+                      borderColor: C.border,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      backgroundColor: goalType === "time" ? "#F5F5F5" : "#fff",
+                    }}
+                  >
+                    <Text>목표 시간</Text>
+                  </Pressable>
+                </View>
+
+                <Field
+                  value={goalValue}
+                  onChangeText={(t) => setGoalValue(onlyDigits(t))}
+                  placeholder="목표를 입력해 주세요"
+                  errorKey="goalValue"
+                  keyboardType="number-pad"
+                />
+                <Field
+                  value={period}
+                  onChangeText={(t) => setPeriod(onlyDigits(t))}
+                  placeholder="난이도 증가 주기(일)"
+                  errorKey="growthPeriodDays"
+                  keyboardType="number-pad"
+                />
+                <Field
+                  value={increment}
+                  onChangeText={(t) => setIncrement(onlyDigits(t))}
+                  placeholder={incPlaceholder}
+                  errorKey="growthIncrement"
+                  keyboardType="number-pad"
+                />
+              </View>
+            )}
+          </View>
+
+          {/* 하단 버튼 */}
+          <View style={{ flexDirection: "row", gap: 12, marginTop: 16 }}>
+            <Pressable
+              onPress={submit}
+              style={{
+                flex: 1,
+                height: 48,
+                borderRadius: 12,
+                backgroundColor: C.primary,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Text style={{ color: "#fff", fontWeight: "800" }}>
+                {mode === "edit" ? "수정하기" : "추가하기"}
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={onClose}
+              style={{
+                flex: 1,
+                height: 48,
+                borderRadius: 12,
+                backgroundColor: C.cancel,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Text style={{ color: "#A1A1A1", fontWeight: "800" }}>취소</Text>
+            </Pressable>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}

--- a/features/routine/components/EditRoutineModal.tsx
+++ b/features/routine/components/EditRoutineModal.tsx
@@ -1,0 +1,392 @@
+// features/routine/components/EditRoutineModal.tsx
+import React, { useEffect, useState } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  Switch,
+  KeyboardAvoidingView,
+  Platform,
+  Alert, // ✅ 추가
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type { AddRoutineForm, GoalType, Routine } from "../types";
+
+const C = {
+  overlay: "rgba(0,0,0,0.55)",
+  card: "#FFFFFF",
+  label: "#5F5548",
+  border: "#E5E7EB",
+  text: "#111827",
+  placeholder: "#9CA3AF",
+  primary: "#6B5B4A",
+  primaryText: "#FFFFFF",
+  cancel: "#E5E7EB",
+  error: "#C2410C",
+};
+
+const CATEGORY_OPTIONS = ["운동", "학업", "기타"] as const;
+
+type Errors = Partial<
+  Record<"title" | "category" | "goalValue" | "growthPeriodDays" | "growthIncrement", string>
+>;
+
+type Props = {
+  visible: boolean;
+  routine: Routine | null; // 수정 대상
+  onClose: () => void;
+  onSubmit: (id: number, form: AddRoutineForm) => Promise<void>;
+  onDelete: (id: number) => Promise<void>; // ✅ 삭제 콜백 추가
+};
+
+export default function EditRoutineModal({ visible, routine, onClose, onSubmit, onDelete }: Props) {
+  const [submitting, setSubmitting] = useState(false); // ✅ 중복 방지
+  const [deleting, setDeleting] = useState(false);
+
+  // form states
+  const [title, setTitle] = useState("");
+  const [category, setCategory] = useState("");
+  const [catOpen, setCatOpen] = useState(false);
+
+  const [growthMode, setGrowthMode] = useState(false);
+  const [goalType, setGoalType] = useState<GoalType>("count");
+  const onlyDigits = (t: string) => t.replace(/[^\d]/g, "");
+
+  const [goalValue, setGoalValue] = useState("");
+  const [period, setPeriod] = useState("");
+  const [increment, setIncrement] = useState("");
+
+  const [errors, setErrors] = useState<Errors>({});
+
+  // 대상 바뀌면 초기값 주입
+  useEffect(() => {
+    if (!routine) return;
+    setTitle(routine.title ?? "");
+    setCategory(routine.category ?? "");
+    setGrowthMode(!!routine.growthMode);
+    setGoalType(routine.goalType ?? "count");
+    setGoalValue(routine.goalValue != null ? String(routine.goalValue) : "");
+    setPeriod(routine.growthPeriodDays != null ? String(routine.growthPeriodDays) : "");
+    setIncrement(routine.growthIncrement != null ? String(routine.growthIncrement) : "");
+    setErrors({});
+    setCatOpen(false);
+  }, [routine]);
+
+  const validate = () => {
+    const e: Errors = {};
+    if (!title.trim()) e.title = "루틴 이름을 입력해 주세요";
+    if (!category.trim()) e.category = "카테고리를 선택해 주세요";
+    if (growthMode) {
+      if (!goalValue) e.goalValue = "목표를 입력해 주세요";
+      if (!period) e.growthPeriodDays = "난이도 증가 주기를 입력해 주세요";
+      if (!increment) e.growthIncrement = "난이도 증가 수치를 입력해 주세요";
+    }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!routine || submitting || deleting) return;
+    if (!validate()) return;
+    try {
+      setSubmitting(true);
+      await onSubmit(routine.id, {
+        title: title.trim(),
+        category: category.trim(),
+        growthMode,
+        goalType: growthMode ? goalType : undefined,
+        goalValue: growthMode ? Number(goalValue) : undefined,
+        growthPeriodDays: growthMode ? Number(period) : undefined,
+        growthIncrement: growthMode ? Number(increment) : undefined,
+      });
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = () => {
+    if (!routine || submitting || deleting) return;
+    Alert.alert(
+      "삭제할까요?",
+      `‘${routine.title}’ 루틴을 영구 삭제합니다.`,
+      [
+        { text: "취소", style: "cancel" },
+        {
+          text: "삭제",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              setDeleting(true);
+              await onDelete(routine.id);
+              onClose();
+            } finally {
+              setDeleting(false);
+            }
+          },
+        },
+      ],
+      { cancelable: true },
+    );
+  };
+
+  const Field = ({
+    value,
+    onChangeText,
+    placeholder,
+    errorKey,
+    keyboardType = "default" as "default" | "number-pad",
+  }: {
+    value: string;
+    onChangeText: (t: string) => void;
+    placeholder: string;
+    errorKey?: keyof Errors;
+    keyboardType?: "default" | "number-pad";
+  }) => {
+    const isErr = errorKey ? !!errors[errorKey] : false;
+    return (
+      <View>
+        <TextInput
+          placeholder={placeholder}
+          placeholderTextColor={C.placeholder}
+          value={value}
+          onChangeText={(t) => {
+            onChangeText(t);
+            if (errorKey && errors[errorKey]) {
+              setErrors({ ...errors, [errorKey]: undefined });
+            }
+          }}
+          keyboardType={keyboardType}
+          style={{
+            borderWidth: 1,
+            borderColor: isErr ? C.error : C.border,
+            borderRadius: 12,
+            paddingHorizontal: 12,
+            paddingVertical: 12,
+            fontSize: 15,
+            color: C.text,
+          }}
+        />
+        {isErr && (
+          <Text style={{ color: C.error, marginTop: 6, fontSize: 12 }}>{errors[errorKey!]}</Text>
+        )}
+      </View>
+    );
+  };
+
+  const incPlaceholder = goalType === "time" ? "난이도 증가 수치(분)" : "난이도 증가 수치";
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        behavior={Platform.select({ ios: "padding", android: undefined })}
+        style={{
+          flex: 1,
+          backgroundColor: C.overlay,
+          justifyContent: "center",
+          paddingHorizontal: 16,
+        }}
+      >
+        <View style={{ backgroundColor: C.card, borderRadius: 18, padding: 16 }}>
+          {/* 헤더: 제목 + 삭제 */}
+          <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 12 }}>
+            <Text style={{ color: C.label, fontWeight: "800", fontSize: 18, flex: 1 }}>
+              루틴 수정
+            </Text>
+            {!!routine && (
+              <Pressable
+                onPress={handleDelete}
+                disabled={submitting || deleting}
+                hitSlop={8}
+                style={{ opacity: deleting ? 0.5 : 1 }}
+              >
+                <Text style={{ color: C.error, fontWeight: "700", fontSize: 14 }}>삭제</Text>
+              </Pressable>
+            )}
+          </View>
+
+          <View style={{ gap: 12 }}>
+            <Field
+              value={title}
+              onChangeText={setTitle}
+              placeholder="루틴 이름을 입력해 주세요"
+              errorKey="title"
+            />
+
+            {/* 카테고리 드롭다운 */}
+            <View>
+              <Pressable
+                onPress={() => setCatOpen((v) => !v)}
+                style={{
+                  borderWidth: 1,
+                  borderColor: errors.category ? C.error : C.border,
+                  borderRadius: 12,
+                  paddingHorizontal: 12,
+                  paddingVertical: 12,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Text style={{ color: category ? C.text : C.placeholder, fontSize: 15 }}>
+                  {category || "카테고리를 선택해 주세요"}
+                </Text>
+                <Ionicons
+                  name={catOpen ? "chevron-up" : "chevron-down"}
+                  size={18}
+                  color={C.placeholder}
+                />
+              </Pressable>
+              {errors.category && (
+                <Text style={{ color: C.error, marginTop: 6, fontSize: 12 }}>
+                  {errors.category}
+                </Text>
+              )}
+              {catOpen && (
+                <View
+                  style={{
+                    marginTop: 6,
+                    borderWidth: 1,
+                    borderColor: C.border,
+                    borderRadius: 12,
+                    overflow: "hidden",
+                    backgroundColor: "#fff",
+                  }}
+                >
+                  {CATEGORY_OPTIONS.map((c, i) => (
+                    <Pressable
+                      key={c}
+                      onPress={() => {
+                        setCategory(c);
+                        setCatOpen(false);
+                        if (errors.category) setErrors({ ...errors, category: undefined });
+                      }}
+                      style={{
+                        paddingVertical: 12,
+                        paddingHorizontal: 12,
+                        borderTopWidth: i === 0 ? 0 : 1,
+                        borderTopColor: C.border,
+                      }}
+                    >
+                      <Text style={{ fontSize: 15, color: C.text }}>{c}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+              )}
+            </View>
+
+            {/* 성장 모드 */}
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "space-between",
+              }}
+            >
+              <Text style={{ color: C.label, fontSize: 15 }}>성장 모드</Text>
+              <Switch value={growthMode} onValueChange={setGrowthMode} />
+            </View>
+
+            {growthMode && (
+              <View style={{ gap: 10 }}>
+                {/* 목표 타입 */}
+                <View style={{ flexDirection: "row", gap: 8 }}>
+                  <Pressable
+                    onPress={() => setGoalType("count")}
+                    style={{
+                      flex: 1,
+                      height: 40,
+                      borderRadius: 10,
+                      borderWidth: 1,
+                      borderColor: C.border,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      backgroundColor: goalType === "count" ? "#F5F5F5" : "#fff",
+                    }}
+                  >
+                    <Text>목표 횟수</Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => setGoalType("time")}
+                    style={{
+                      flex: 1,
+                      height: 40,
+                      borderRadius: 10,
+                      borderWidth: 1,
+                      borderColor: C.border,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      backgroundColor: goalType === "time" ? "#F5F5F5" : "#fff",
+                    }}
+                  >
+                    <Text>목표 시간</Text>
+                  </Pressable>
+                </View>
+
+                <Field
+                  value={goalValue}
+                  onChangeText={(t) => setGoalValue(onlyDigits(t))}
+                  placeholder="목표를 입력해 주세요"
+                  errorKey="goalValue"
+                  keyboardType="number-pad"
+                />
+                <Field
+                  value={period}
+                  onChangeText={(t) => setPeriod(onlyDigits(t))}
+                  placeholder="난이도 증가 주기(일)"
+                  errorKey="growthPeriodDays"
+                  keyboardType="number-pad"
+                />
+                <Field
+                  value={increment}
+                  onChangeText={(t) => setIncrement(onlyDigits(t))}
+                  placeholder={incPlaceholder}
+                  errorKey="growthIncrement"
+                  keyboardType="number-pad"
+                />
+              </View>
+            )}
+          </View>
+
+          {/* 버튼 */}
+          <View style={{ flexDirection: "row", gap: 12, marginTop: 16 }}>
+            <Pressable
+              onPress={handleSubmit}
+              disabled={submitting || deleting}
+              style={{
+                flex: 1,
+                height: 48,
+                borderRadius: 12,
+                backgroundColor: C.primary,
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: submitting || deleting ? 0.6 : 1,
+              }}
+            >
+              <Text style={{ color: "#fff", fontWeight: "800" }}>
+                {submitting ? "저장 중..." : "수정하기"}
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={onClose}
+              disabled={submitting || deleting}
+              style={{
+                flex: 1,
+                height: 48,
+                borderRadius: 12,
+                backgroundColor: C.cancel,
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: submitting || deleting ? 0.6 : 1,
+              }}
+            >
+              <Text style={{ color: "#A1A1A1", fontWeight: "800" }}>취소</Text>
+            </Pressable>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}

--- a/features/routine/components/GrowthSuggestionModal.tsx
+++ b/features/routine/components/GrowthSuggestionModal.tsx
@@ -1,0 +1,91 @@
+// features/routine/components/GrowthSuggestionModal.tsx
+import React from "react";
+import { Modal, View, Text, Pressable, StyleSheet } from "react-native";
+import type { Routine } from "../types";
+
+type Props = {
+  visible: boolean;
+  routine: Routine | null;
+  onClose: () => void;
+  onAdjust: (id: number, action: "keep" | "inc" | "dec") => void;
+  suggestionKind?: "inc" | "dec" | null;
+};
+
+export default function GrowthSuggestionModal({
+  visible,
+  routine,
+  onClose,
+  onAdjust,
+  suggestionKind,
+}: Props) {
+  if (!routine) return null;
+
+  const showInc = suggestionKind === "inc";
+  const showDec = suggestionKind === "dec";
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={s.overlay}>
+        <View style={s.card}>
+          <Text style={s.title}>성장 모드 제안</Text>
+          <Text style={s.desc}>
+            {routine.title}
+            {"\n"}
+            목표를 조정할까요?
+          </Text>
+
+          <View style={s.actions}>
+            <Pressable style={[s.btn, s.keep]} onPress={() => onAdjust(routine.id, "keep")}>
+              <Text style={s.light}>유지</Text>
+            </Pressable>
+
+            {showInc && (
+              <Pressable style={[s.btn, s.inc]} onPress={() => onAdjust(routine.id, "inc")}>
+                <Text style={s.light}>증가</Text>
+              </Pressable>
+            )}
+
+            {showDec && (
+              <Pressable style={[s.btn, s.dec]} onPress={() => onAdjust(routine.id, "dec")}>
+                <Text style={s.light}>감소</Text>
+              </Pressable>
+            )}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+// GrowthSuggestionModal.tsx (스타일 부분만 교체)
+const s = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.55)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  card: { width: "100%", maxWidth: 320, backgroundColor: "#fff", borderRadius: 16, padding: 20 },
+  title: { fontSize: 18, fontWeight: "800", color: "#5F5548", marginBottom: 10 },
+  desc: { fontSize: 15, color: "#111827", marginBottom: 20, textAlign: "center" },
+
+  actions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+
+  btn: {
+    flex: 1,
+    height: 44,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  keep: { backgroundColor: "#10B981" },
+  inc: { backgroundColor: "#3B82F6" },
+  dec: { backgroundColor: "#EF4444" },
+  light: { fontWeight: "700", color: "#fff" },
+});

--- a/features/routine/components/RoutineBottomSheet.tsx
+++ b/features/routine/components/RoutineBottomSheet.tsx
@@ -1,0 +1,95 @@
+// features/routine/components/RoutineBottomSheet.tsx
+import React, { forwardRef, useMemo } from "react";
+import { View, Text, FlatList, Pressable } from "react-native";
+import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
+import { Ionicons } from "@expo/vector-icons";
+import RoutineCard from "./RoutineCard";
+import type { Routine } from "../types";
+
+type Props = {
+  routines: Routine[];
+  onPressComplete?: (id: number) => void | Promise<void>;
+  onPressAdd: () => void;
+  onPressEdit: (r: Routine) => void;
+  initialIndex?: number;
+  snapPoints?: (string | number)[];
+  headerDateText?: string;
+  headerSubtitle?: string;
+};
+
+const RoutineBottomSheet = forwardRef<BottomSheet, Props>(
+  (
+    {
+      routines,
+      onPressAdd,
+      onPressEdit,
+      initialIndex = 0,
+      snapPoints,
+      headerDateText,
+      headerSubtitle,
+    },
+    ref,
+  ) => {
+    const points = useMemo(() => snapPoints ?? ["18%", "56%", "92%"], [snapPoints]);
+
+    return (
+      <BottomSheet
+        ref={ref}
+        index={initialIndex}
+        snapPoints={points}
+        enablePanDownToClose={false}
+        handleIndicatorStyle={{ width: 60, backgroundColor: "#e5e7eb" }}
+        backgroundStyle={{
+          backgroundColor: "white",
+          borderTopLeftRadius: 20,
+          borderTopRightRadius: 20,
+        }}
+      >
+        <BottomSheetView style={{ flex: 1 }}>
+          {(headerDateText || headerSubtitle) && (
+            <View style={{ paddingHorizontal: 20, paddingTop: 8, paddingBottom: 10 }}>
+              {!!headerDateText && (
+                <Text style={{ fontSize: 20, fontWeight: "800", color: "#3F3429" }}>
+                  {headerDateText}
+                </Text>
+              )}
+              {!!headerSubtitle && (
+                <Text style={{ marginTop: 4, fontSize: 14, color: "#877C70" }}>
+                  {headerSubtitle}
+                </Text>
+              )}
+            </View>
+          )}
+
+          <FlatList
+            data={routines}
+            keyExtractor={(item) => String(item.id)}
+            contentContainerStyle={{ paddingHorizontal: 16, rowGap: 12, paddingBottom: 36 }}
+            renderItem={({ item }) => <RoutineCard routine={item} onPressEdit={onPressEdit} />}
+            ListFooterComponent={
+              <View style={{ alignItems: "center", marginTop: 14, marginBottom: 10 }}>
+                <Pressable
+                  onPress={onPressAdd}
+                  style={{
+                    width: 44,
+                    height: 44,
+                    borderRadius: 22,
+                    backgroundColor: "#F4F1EA",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    borderWidth: 1,
+                    borderColor: "rgba(0,0,0,0.07)",
+                  }}
+                >
+                  <Ionicons name="add" size={22} color="#6B5B4A" />
+                </Pressable>
+              </View>
+            }
+          />
+        </BottomSheetView>
+      </BottomSheet>
+    );
+  },
+);
+
+export default RoutineBottomSheet;

--- a/features/routine/components/RoutineCard.tsx
+++ b/features/routine/components/RoutineCard.tsx
@@ -1,0 +1,69 @@
+// features/routine/components/RoutineCard.tsx
+import React from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type { Routine } from "../types";
+
+type Props = {
+  routine: Routine;
+  onPressEdit: (r: Routine) => void;
+};
+
+export default function RoutineCard({ routine, onPressEdit }: Props) {
+  const goalUnit = routine.goalType === "time" ? "시간" : "개";
+  const goalText = routine.goalValue != null ? ` ${routine.goalValue}${goalUnit}` : "";
+
+  return (
+    <View style={s.card}>
+      <View style={s.left}>
+        <View style={s.titleRow}>
+          <Text style={s.title}>{routine.title}</Text>
+          <TouchableOpacity
+            onPress={() => onPressEdit(routine)}
+            hitSlop={10}
+            style={{ marginLeft: 6 }}
+          >
+            <Ionicons name="create-outline" size={16} color="#6B5B4A" />
+          </TouchableOpacity>
+        </View>
+        {!!routine.subtitleHint && <Text style={s.subtitle}>{routine.subtitleHint}</Text>}
+      </View>
+
+      {typeof routine.streakDays === "number" && routine.streakDays > 0 && (
+        <View style={s.badgeWrap}>
+          <Ionicons name="flame" size={18} color="#FF8A00" style={{ marginRight: 6 }} />
+          <Text style={s.badgeText}>{routine.streakDays}일 연속!</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  card: {
+    backgroundColor: "#F4F1EA",
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    flexDirection: "row",
+    alignItems: "center",
+    minHeight: 88,
+    shadowOpacity: 0.05,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 1,
+  },
+  left: { flex: 1, paddingRight: 8 },
+  titleRow: { flexDirection: "row", alignItems: "center" },
+  title: { fontSize: 18, fontWeight: "800", color: "#3F3429" },
+  subtitle: { marginTop: 6, fontSize: 14, color: "#B0A89F" },
+  badgeWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#FFF1E5",
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  badgeText: { color: "#F97316", fontWeight: "700", fontSize: 12 },
+});

--- a/features/routine/hooks/useAddRoutineModal.ts
+++ b/features/routine/hooks/useAddRoutineModal.ts
@@ -1,0 +1,18 @@
+import { useCallback, useState } from "react";
+import type { AddRoutineForm } from "../types";
+
+export const useAddRoutineModal = (onSubmitForm: (f: AddRoutineForm) => Promise<void>) => {
+  const [visible, setVisible] = useState(false);
+
+  const open = useCallback(() => setVisible(true), []);
+  const close = useCallback(() => setVisible(false), []);
+  const submit = useCallback(
+    async (f: AddRoutineForm) => {
+      await onSubmitForm(f);
+      setVisible(false);
+    },
+    [onSubmitForm],
+  );
+
+  return { visible, open, close, submit };
+};

--- a/features/routine/hooks/useEditRoutineModal.ts
+++ b/features/routine/hooks/useEditRoutineModal.ts
@@ -1,0 +1,30 @@
+// features/routine/hooks/useEditRoutineModal.ts
+import { useCallback, useState } from "react";
+import type { AddRoutineForm, Routine } from "../types";
+
+export const useEditRoutineModal = (
+  onSubmit: (id: number, f: AddRoutineForm) => Promise<void>,
+  onDelete: (id: number) => Promise<void>, // ✅ 추가
+) => {
+  const [target, setTarget] = useState<Routine | null>(null);
+
+  const open = useCallback((r: Routine) => setTarget(r), []);
+  const close = useCallback(() => setTarget(null), []);
+
+  const submit = useCallback(
+    async (f: AddRoutineForm) => {
+      if (!target) return;
+      await onSubmit(target.id, f);
+      setTarget(null);
+    },
+    [onSubmit, target],
+  );
+
+  const remove = useCallback(async () => {
+    if (!target) return;
+    await onDelete(target.id);
+    setTarget(null);
+  }, [onDelete, target]);
+
+  return { target, open, close, submit, remove, visible: !!target };
+};

--- a/features/routine/hooks/useGrowthCheck.tsx
+++ b/features/routine/hooks/useGrowthCheck.tsx
@@ -1,0 +1,191 @@
+// features/routine/hooks/useGrowthCheck.tsx
+import React, { useEffect, useRef, useCallback } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useRoutineStore } from "../store/store";
+import type { AddRoutineForm, Routine, RoutineHistoryItem } from "../types";
+import { usePopupQueue } from "@features/routine/common/popupQueue";
+import GrowthSuggestionModal from "@features/routine/components/GrowthSuggestionModal";
+
+/** yyyy-MM-dd만 사용 */
+const dOnly = (s?: string) => (s ? s.slice(0, 10) : "");
+
+/** 성공/실패 판정 (호환) */
+const isSuccess = (x: RoutineHistoryItem) => {
+  const s = String(x?.status ?? "").toUpperCase();
+  return x?.completed === true || x?.done === true || s === "DONE" || s === "SUCCESS";
+};
+const isFailure = (x: RoutineHistoryItem) => {
+  const s = String(x?.status ?? "").toUpperCase();
+  return x?.completed === false || x?.done === false || s === "FAIL";
+};
+
+/** 날짜 유틸 */
+const todayStr = () => dOnly(new Date().toISOString());
+const dateAddDays = (isoDate: string, delta: number) => {
+  const d = new Date(`${isoDate}T00:00:00`);
+  d.setDate(d.getDate() + delta);
+  return dOnly(d.toISOString());
+};
+const dateCmp = (a: string, b: string) => (a === b ? 0 : a < b ? -1 : 1);
+
+function buildDayStatusMap(r: Routine) {
+  const m = new Map<string, "success" | "failure">();
+  const anchor = dOnly(r.lastAdjustAt);
+  const hist = Array.isArray(r.history) ? r.history! : [];
+  for (const it of hist) {
+    const d = dOnly(it?.date);
+    if (!d) continue;
+    if (anchor && dateCmp(d, anchor) <= 0) continue;
+    if (isSuccess(it)) m.set(d, "success");
+    else if (isFailure(it) && !m.has(d)) m.set(d, "failure");
+  }
+  return { map: m, anchor };
+}
+
+/** today 이하 최신 기록일 */
+function latestRecordedOnOrBefore(map: Map<string, "success" | "failure">, upper: string) {
+  let latest: string | null = null;
+  for (const d of map.keys()) {
+    if (dateCmp(d, upper) > 0) continue;
+    if (!latest || dateCmp(d, latest) > 0) latest = d;
+  }
+  return latest;
+}
+
+function countConsecutiveBounded(
+  map: Map<string, "success" | "failure">,
+  mode: "success" | "failure",
+  need: number,
+  anchor?: string | null,
+) {
+  const upper = todayStr();
+  const start = latestRecordedOnOrBefore(map, upper) ?? upper;
+  let cnt = 0;
+  let cursor = start;
+  for (let step = 0; step < need; step++) {
+    if (anchor && dateCmp(cursor, anchor) <= 0) break; // 앵커 이전 금지
+    const v = map.get(cursor);
+    if (mode === "success") {
+      if (v === "success") cnt += 1;
+      else break; // 실패/미기록 → 끊김
+    } else {
+      if (v === "success") break; // 성공이면 끊김
+      cnt += 1; // 실패/미기록 → 실패로 카운트
+    }
+    cursor = dateAddDays(cursor, -1);
+  }
+  return cnt;
+}
+
+/** 훅: 성장 제안 팝업을 전역 팝업 큐에 '배치'로 enqueue (실패들 → 성공들 순서로 모두) */
+export function useGrowthCheck() {
+  const { routines, loading, update } = useRoutineStore();
+  const enqueue = usePopupQueue((s) => s.enqueue);
+
+  /** 중복 스캔 방지 */
+  const scanningRef = useRef(false);
+
+  /** 후보 스캔 + 배치 enqueue (하루 1회) */
+  const scanNow = useCallback(async () => {
+    if (loading || routines.length === 0) return;
+    if (scanningRef.current) return;
+    scanningRef.current = true;
+
+    try {
+      const today = todayStr();
+      const lastChecked = await AsyncStorage.getItem("growthCheckDate");
+      if (lastChecked === today) return; // 오늘 이미 배치 처리됨
+
+      type Cand = { r: Routine; streak: number };
+      const failureCands: Cand[] = [];
+      const successCands: Cand[] = [];
+
+      for (const r of routines) {
+        if (!r.growthMode || !r.growthPeriodDays) continue;
+
+        const need = r.growthPeriodDays!;
+        const { map, anchor } = buildDayStatusMap(r);
+
+        // 1) 연속 실패(미기록 포함) — 우선순위 높음
+        const fs = countConsecutiveBounded(map, "failure", need, anchor);
+        if (fs >= need) {
+          failureCands.push({ r, streak: fs });
+          continue; // 실패 후보면 성공은 안 봐도 됨
+        }
+
+        // 2) 연속 성공
+        const ss = countConsecutiveBounded(map, "success", need, anchor);
+        if (ss >= need) {
+          successCands.push({ r, streak: ss });
+        }
+      }
+
+      // 후보가 하나도 없으면 종료
+      if (failureCands.length === 0 && successCands.length === 0) return;
+
+      // 정렬: 각 그룹 내 streak 긴 것 우선
+      failureCands.sort((a, b) => b.streak - a.streak);
+      successCands.sort((a, b) => b.streak - a.streak);
+
+      // ✅ 하루 1회 제한: 이번 배치를 오늘자로 마킹
+      await AsyncStorage.setItem("growthCheckDate", today);
+
+      // 실패들 → 성공들 순으로 모두 큐에 넣기
+      const batch = [
+        ...failureCands.map((c) => ({ r: c.r, kind: "dec" as const })),
+        ...successCands.map((c) => ({ r: c.r, kind: "inc" as const })),
+      ];
+
+      batch.forEach(({ r, kind }) => {
+        enqueue((dismiss) => (
+          <GrowthSuggestionModal
+            visible
+            routine={r}
+            suggestionKind={kind}
+            onClose={dismiss}
+            onAdjust={async (id, action) => {
+              // 버튼 가드: 제안 종류에 맞는 버튼만
+              if (kind === "inc" && action === "dec") return;
+              if (kind === "dec" && action === "inc") return;
+
+              const cur = r.goalValue ?? 0;
+              const step = r.growthIncrement ?? 0;
+              let next = cur;
+              if (action === "inc") next = cur + step;
+              if (action === "dec") next = Math.max(1, cur - step);
+
+              const form: AddRoutineForm = {
+                title: r.title,
+                category: r.category,
+                growthMode: !!r.growthMode,
+                goalType: r.growthMode ? r.goalType : undefined,
+                goalValue: r.growthMode ? next : undefined,
+                growthPeriodDays: r.growthPeriodDays,
+                growthIncrement: r.growthIncrement,
+                // 조정 시 새 사이클 시작: 원하면 아래 주석 해제
+                // lastAdjustAt: new Date().toISOString(),
+              };
+
+              await update(id, form);
+              dismiss(); // 닫으면 큐가 다음 팝업으로 진행
+            }}
+          />
+        ));
+      });
+    } finally {
+      scanningRef.current = false;
+    }
+  }, [loading, routines, update, enqueue]);
+
+  /** 화면 진입 시 자동 1회 스캔 */
+  useEffect(() => {
+    scanNow();
+  }, [scanNow]);
+
+  /** 테스트 편의: 오늘 1회 제한 해제 */
+  const resetTodayOnce = useCallback(async () => {
+    await AsyncStorage.removeItem("growthCheckDate");
+  }, []);
+
+  return { scanNow, resetTodayOnce };
+}

--- a/features/routine/hooks/useRoutines.ts
+++ b/features/routine/hooks/useRoutines.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useRoutineStore } from "../store/store";
+
+export const useRoutines = () => {
+  const { routines, loading, error, load, create, toggleComplete } = useRoutineStore();
+
+  useEffect(() => {
+    if (!routines.length) void load();
+  }, [routines.length, load]);
+
+  return { routines, loading, error, create, toggleComplete, reload: load };
+};

--- a/features/routine/store/store.ts
+++ b/features/routine/store/store.ts
@@ -1,0 +1,113 @@
+// features/routine/store/routine.store.ts
+import { create } from "zustand";
+import {
+  addRoutineApi,
+  completeRoutineApi,
+  deleteRoutineApi,
+  fetchRoutines,
+  updateRoutineApi,
+} from "../api/routines";
+import type { AddRoutineForm, Routine } from "../types";
+
+type State = {
+  routines: Routine[];
+  loading: boolean;
+  error?: string;
+  mutatingId?: number | null; // 업데이트/완료 중인 아이템
+  deletingId?: number | null; // 삭제 중인 아이템
+};
+
+type Actions = {
+  load: () => Promise<void>;
+  create: (form: AddRoutineForm) => Promise<void>;
+  update: (id: number, form: AddRoutineForm) => Promise<void>;
+  remove: (id: number) => Promise<void>;
+  toggleComplete: (id: number) => Promise<void>;
+};
+
+const byId = (arr: Routine[], id: number) => arr.find((r) => Number(r.id) === Number(id));
+const replace = (arr: Routine[], id: number, patch: Partial<Routine>) =>
+  arr.map((r) => (Number(r.id) === Number(id) ? { ...r, ...patch } : r));
+const drop = (arr: Routine[], id: number) => arr.filter((r) => Number(r.id) !== Number(id));
+
+export const useRoutineStore = create<State & Actions>((set, get) => ({
+  routines: [],
+  loading: false,
+  error: undefined,
+  mutatingId: null,
+  deletingId: null,
+
+  load: async () => {
+    set({ loading: true, error: undefined });
+    try {
+      const rows = await fetchRoutines();
+      set({ routines: rows });
+    } catch {
+      set({ error: "루틴을 불러오지 못했습니다." });
+    } finally {
+      set({ loading: false });
+    }
+  },
+
+  create: async (form) => {
+    // API가 목인 경우에도 즉시 반영되도록
+    const created = await addRoutineApi(form);
+    set((s) => ({ routines: [created, ...s.routines] }));
+  },
+
+  update: async (id, form) => {
+    // 낙관적 반영
+    const prev = get().routines;
+    set({
+      routines: replace(prev, id, form as Partial<Routine>),
+      mutatingId: id,
+      error: undefined,
+    });
+    try {
+      const saved = await updateRoutineApi(id, form);
+      // API에서 계산된 필드가 오면 덮어씀
+      set((s) => ({
+        routines: replace(s.routines, id, saved as Partial<Routine>),
+        mutatingId: null,
+      }));
+    } catch (e) {
+      set({ routines: prev, mutatingId: null, error: "루틴 수정 실패" });
+      throw e;
+    }
+  },
+
+  remove: async (id) => {
+    // 낙관적 삭제
+    const prev = get().routines;
+    set({ routines: drop(prev, id), deletingId: id, error: undefined });
+    try {
+      await deleteRoutineApi(id);
+      set({ deletingId: null });
+    } catch (e) {
+      set({ routines: prev, deletingId: null, error: "루틴 삭제 실패" });
+      throw e;
+    }
+  },
+
+  toggleComplete: async (id) => {
+    // 현재 상태 기준으로 토글
+    const prev = get().routines;
+    const target = byId(prev, id);
+    if (!target) return;
+
+    const nextCompleted = !target.completedToday;
+    set({
+      routines: replace(prev, id, { completedToday: nextCompleted }),
+      mutatingId: id,
+      error: undefined,
+    });
+
+    try {
+      // 서버가 상태값을 받는 형태라면: await completeRoutineApi(id, nextCompleted)
+      await completeRoutineApi(id);
+      set({ mutatingId: null });
+    } catch (e) {
+      set({ routines: prev, mutatingId: null, error: "완료 상태 변경 실패" });
+    }
+  },
+}));

--- a/features/routine/types.ts
+++ b/features/routine/types.ts
@@ -1,0 +1,46 @@
+// features/routine/types.ts
+
+export type GoalType = "count" | "time";
+
+export type RoutineHistoryItem = {
+  date: string; // "yyyy-MM-dd" 또는 ISO
+  completed?: boolean; // true=성공, false=실패
+  done?: boolean; // 호환
+  status?: "DONE" | "SUCCESS" | "FAIL" | string; // 호환
+};
+
+export type Routine = {
+  id: number;
+  title: string;
+  category: string;
+
+  // 성장 모드
+  growthMode?: boolean;
+  goalType?: GoalType; // count=회, time=분
+  goalValue?: number; // 현재 목표(회/분)
+  growthPeriodDays?: number; // N일(연속 기준)
+  growthIncrement?: number; // 증감 수치(회/분)
+
+  // 사이클 기준점(이 이후부터 연속 계산)
+  lastAdjustAt?: string; // ISO
+
+  // UI 보조(옵션)
+  subtitleHint?: string;
+  streakDays?: number;
+
+  // 히스토리
+  history?: RoutineHistoryItem[];
+  completedToday?: boolean;
+};
+
+/** 루틴 추가/수정 폼 */
+export type AddRoutineForm = {
+  title: string;
+  category: string;
+  growthMode: boolean;
+  goalType?: GoalType;
+  goalValue?: number;
+  growthPeriodDays?: number;
+  growthIncrement?: number;
+  lastAdjustAt?: string;
+};


### PR DESCRIPTION
### 요약
- 루틴 등록(AddRoutineModal + store 연동)
- 성장 모드(goalType/value/period/increment) 설정 및 검증
- 기록 기반 증가/감소/유지 제안(useGrowthCheck + PopupHost + GrowthSuggestionModal)
- 리스트/카드 UI 토대(RoutineBottomSheet, RoutineCard) 및 초기 로드 훅(useRoutines)

### 주요 변경
- types: 루틴/히스토리/등록 폼/성장모드 타입 정리
- api: 목 API(add/update/delete/complete) 추가 및 전환 가이드 주석
- store: create/update/toggleComplete 낙관 반영, 삭제 처리
- utils: calculateSuggestion, generateProgression 유틸
- components: Add/Edit/GrowthSuggestion 모달, 바텀시트/카드 UI
- hooks: useAddRoutineModal/useEditRoutineModal/useGrowthCheck/useRoutines
- common: popupQueue, PopupHost

### 수용 기준(AC)
1) 필수값 미입력 시 에러 → 등록/수정 차단  
2) 생성 성공 시 목록 상단 추가 & 모달 닫힘  
3) 성장 모드 on 시 필드 검증 동작  
4) time 단위 ‘분’ 표기 일관성  
5) 제안 모달 하루 1회 제한 + 버튼 가드(inc/dec/keep)  
6) 목표값 업데이트가 store에 반영

### 테스트 방법
1. “루틴 추가” → 제목/카테고리 입력 → 추가하기  
2. 루틴 편집 → 성장 모드 on → 값 입력 후 저장  
3. 히스토리 데이터에 따라 제안 모달 노출 확인(inc/dec 케이스)  
4. 증가/감소/유지 버튼 클릭 시 목표 업데이트 확인  
5. 앱 재진입 시 하루 1회 제한 동작 확인


Closes #3 
